### PR TITLE
Update DownloadTropoFile.m to handle downloads from 2023 onwards

### DIFF
--- a/CODE/READ/DownloadTropoFile.m
+++ b/CODE/READ/DownloadTropoFile.m
@@ -27,9 +27,8 @@ doy_ 	= sprintf('%03d',doy);
 % define variables for download
 target = [Path.DATA, 'TROPO/', yyyy_, '/', doy_];
 [~, ~] = mkdir(target);
-if (yyyy > 2023) && (yyyy == 2023 && doy >= 48)
-    % starting with 17 Feb 2023 long filenames are used (IGSMAIL-8313)
-    % ||| not working
+if (yyyy > 2023) || (yyyy == 2023 && doy >= 27)
+    % starting with 27 Jan 2023 long filenames are used (IGSMAIL-8313)
     URL_file = ['IGS0OPSFIN_' yyyy_ doy_ '0000_01D_05M_' upper(stationlong) '_TRO.TRO.gz'];
 else
     URL_file = [lower(stationlong(1:4)) doy_ '0.' yyyy_(3:4) 'zpd.gz'];


### PR DESCRIPTION
It seems there was a bug in the logical condition where "&&" was used instead of "||". I also changed the threshold date from Feb 17 to Jan 27, since that seems to be the cutoff date for long file names in the CDDIS server: 
https://cddis.nasa.gov/archive/gnss/products/troposphere/zpd/2023/027/