### PR TITLE
Decompress CNES MGEX biases

### DIFF
--- a/CODE/READ/DownloadBiases.m
+++ b/CODE/READ/DownloadBiases.m
@@ -175,6 +175,7 @@ switch settings.BIASES.code
         if file_status == 0
             errordlg('No CNES MGEX Biases found on server. Please specify different source!', 'Error');
         end
+        decompressed = unzip_and_delete(file(1), target(1));
         % save file-path
         settings.BIASES.code_file = decompressed{1};
 


### PR DESCRIPTION
CNES MGEX biases are downloaded but the `gz` file is never decompressed, leading to an error when trying to use it. Fixed by using `unzip_and_delete` similar to the other MGEX sources