### PR TITLE
Fix the observation interval detection

### DIFF
--- a/CODE/READ/anheader.m
+++ b/CODE/READ/anheader.m
@@ -354,7 +354,7 @@ if ~isempty(interval)
     obs.interval = interval;    % take from RINEX header
 else
     [~, ~, interval] = analyzeRinexName(path_file);     % take from filename
-    if ~isempty(interval)
+    if isempty(interval)
         interval = extractObsInterval(path_file);       % calculate from first two epochs
     end
     obs.interval = interval;


### PR DESCRIPTION
Processing currently fails if observation interval cannot be parsed from the file name.
It seems the check for empty interval is inverted in the newly added code in `anheader`